### PR TITLE
add .java extension support in Readme.md to avoid possible confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ How to use PVS-Studio for FREE? [![Build Status](https://travis-ci.org/viva64/ho
 
   The utility will add comments to the files located in the specified folders
   and subfolders. The comments are added to the beginning of the files with the
-  extensions .c, .cc, .cpp, .cp, .cxx, .c++, .cs. You don't have to change header
+  extensions .c, .cc, .cpp, .cp, .cxx, .c++, .cs, .java. You don't have to change header
   files. If you use files with other extensions, you can customize this utility
   for your needs.
 


### PR DESCRIPTION
Please refer to issue #18 , which I got really confused in the beginning, as `.java` extension was not included in Readme.md, while the latest code actually support `.java`, so I think sync the README will possibly prevent such kind of unnecessary confusions.

Meanwhile, I'd suggest update the release part ASAP, as the latest release it not based on latest code and DOESN'T support generating comments for `.java` files.