### PR TITLE
Convert to unsigned char arguments of isalnum(), etc.

### DIFF
--- a/comments.cpp
+++ b/comments.cpp
@@ -25,7 +25,7 @@ namespace PvsStudioFreeComments
   {
     size_t width = 0;
 
-    while (begin != end && !isalnum(*begin))
+    while (begin != end && !isalnum(static_cast<const unsigned char>(*begin)))
     {
       width += (*begin == '\t' ? 4 : (*begin == ' ' ? 1 : 0));
       ++begin;
@@ -36,7 +36,7 @@ namespace PvsStudioFreeComments
       return false;
     }
 
-    while (begin != end && isspace(*(end - 1)))
+    while (begin != end && isspace(static_cast<const unsigned char>(*(end - 1))))
     {
       --end;
     }
@@ -109,7 +109,7 @@ namespace PvsStudioFreeComments
 
   const char* CommentsParser::readComment(const char* it)
   {
-    while (isspace(*it) && m_skippedLines < MaxSkippedLines)
+    while (isspace(static_cast<const unsigned char>(*it)) && m_skippedLines < MaxSkippedLines)
     {
       if (it[0] == '\n')
         ++m_skippedLines;


### PR DESCRIPTION
To use functions from <cctype>safely with plain chars (or signed chars), the argument should first be converted to unsigned char.
When using English comments as the very first non-empty line, it's ok. But as soon as other unicode symbols appear... 
While it works in release build (not always?), in debug some crt will assert failure.

P.S. PVS Studio doesn't issue that in the project:/